### PR TITLE
Fix ajax_options default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+0.1.5 - unreleased
+------------------
+
+- Fix syntax error in javascript when ajax_options are not specified. Use a 
+  string representing an empty javascript object as the default for 
+  ajax_options.
+
 0.1.4 (2010-12-17)
 ------------------
 

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -15,7 +15,7 @@ class FormView(object):
 
     def __call__(self):
         use_ajax = getattr(self, 'use_ajax', False)
-        ajax_options = getattr(self, 'ajax_options', '')
+        ajax_options = getattr(self, 'ajax_options', '{}')
         schema = self.schema.bind(request=self.request)
         form = self.form_class(schema, buttons=self.buttons, use_ajax=use_ajax,
                                ajax_options=ajax_options)


### PR DESCRIPTION
Use `'{}'` (empty object literal) as the default for `ajax_options`. With the current `''`, the callback function for the form will have a syntax error:

```
  "var extra_options = ;"
```
