### PR TITLE
Add "includeme" for configure locale dirs.

### DIFF
--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -317,3 +317,7 @@ class CSRFSchema(colander.Schema):
         validator=deferred_csrf_validator,
         )
 
+
+def includeme(config):
+    config.add_translation_dirs('deform:locale/', 'colander:locale/')
+    return config


### PR DESCRIPTION
Why:
pyramid_deform provides multiple packages that need translation dirs
such as deform, colander and pyramid_deform itself in prospect.
