### PR TITLE
2 small documentation changes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,7 +83,7 @@ something like this:
     <body>
       <h1>Edit ${context.title}</h1>
       <form tal:replace="structure form" />
-    </div>
+    </body>
   </html>
 
 Wizard

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ You can then write a ``PageEditView`` using
   from pyramid_deform import FormView
 
   class PageEditView(FormView):
-      schema = PageSchema
+      schema = PageSchema()
       buttons = ('save',)
 
       def save_success(self, appstruct):


### PR DESCRIPTION
I had to make these 2 changes before I could get the example in the documentation to run.

The 2 changes are:
1. Replacing &lt;/div&gt; with &lt;/body&gt; in the template, to make it valid HTML
2. Using an instance of the Colander schema instead of the class itself.
   I'm not 100% sure about this one, but I was getting an exception on the [call to bind](https://github.com/Pylons/pyramid_deform/blob/master/pyramid_deform/__init__.py#L24) that my change seemed to fix.
