### PR TITLE
Add 'get_bind_data' method to FormView

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@ Next release
 ------------
 
 - Python 3 compatibility.
+- Add 'get_bind_data' method to FormView, to allow subclasses the ability
+  to define arbitrary data for binding with the schema.
 
 0.2a4 (2012-04-23)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,3 +108,4 @@ Contributors
 
 Chris McDonough, 2010/11/27
 Daniel Nouri, 2012/03/30
+Josh Jaques, 2012/04/26

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,6 +119,28 @@ something like this::
     </body>
   </html>
 
+
+Deferred Colander Schemas
+-------------------------
+``pyramid_deform.FormView`` will `bind
+<http://docs.pylonsproject.org/projects/colander/en/latest/binding.html>`_ the
+schema by default to the pyramid request. You may wish to bind additional data
+to the schema, which you can do by overriding the get_bind_data method in your
+subclass, like this::
+
+    class PageEditView(FormView):
+        ...
+
+        def get_bind_data(self):
+            # ensure we get any base data defined by FormView
+            data = super(PageEditView, self).get_bind_data()
+            # add any custom data here
+            data.update({
+                'bind_this_field': 'to this value',
+                'and_this_field': 'to this value'
+            })
+            return data
+
 Wizard
 ------
 

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -47,10 +47,13 @@ class FormView(object):
     def __init__(self, request):
         self.request = request
 
+    def get_bind_data(self):
+        return {'request': self.request}
+
     def __call__(self):
         use_ajax = getattr(self, 'use_ajax', False)
         ajax_options = getattr(self, 'ajax_options', '{}')
-        self.schema = self.schema.bind(request=self.request)
+        self.schema = self.schema.bind(**self.get_bind_data())
         form = self.form_class(self.schema, buttons=self.buttons,
                                use_ajax=use_ajax, ajax_options=ajax_options)
         self.before(form)

--- a/pyramid_deform/tests.py
+++ b/pyramid_deform/tests.py
@@ -93,6 +93,22 @@ class TestFormView(unittest.TestCase):
         self.assertEqual(result,
                          {'css_links': (), 'js_links': (), 'form': 'failure'})
 
+    def test_get_bind_data_contains_request(self):
+        request = DummyRequest()
+        inst = self._makeOne(request)
+        data = inst.get_bind_data()
+        self.assertTrue('request' in data)
+
+    def test__call__binds_schema_with_get_bind_data(self):
+        schema = DummySchema()
+        request = DummyRequest()
+        inst = self._makeOne(request)
+        inst.schema = schema
+        inst.form_class = DummyForm
+        inst()
+        # note: DummySchema sets kw to the bind data
+        self.assertEquals(schema.kw, inst.get_bind_data())
+
 class TestFormWizardView(unittest.TestCase):
     def _makeOne(self, wizard):
         from pyramid_deform import FormWizardView


### PR DESCRIPTION
Allows subclasses the ability                                                                                                                                                                                                            to define arbitrary data for binding with the schema. 
