### PR TITLE
New form_options setting to configure form instance (+ more documentation)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,16 +1,20 @@
 API Documentation
 =================
 
-Form views
-----------
 
 .. automodule:: pyramid_deform
    :members: includeme
+
+Form view
+---------
 
 .. autoclass:: FormView
    :members: 
 
     .. automethod:: __call__
+
+Other
+-----
 
 .. autoclass:: CSRFSchema
    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,7 @@ You can then write a ``PageEditView`` using
   class PageEditView(FormView):
       schema = PageSchema()
       buttons = ('save',)
+      form_options = {'formid': 'pyramid-deform'}
 
       def save_success(self, appstruct):
           context = self.request.context
@@ -103,6 +104,13 @@ it's a required field.
 
 We use the ``appstruct`` method to pre-fill the form with values from
 the page object that we edit (i.e. ``context``).
+
+We also provide a ``form_options`` dict -- this structure can contain
+any options to be passed as keyword arguments to the form class' ``__init__``
+method.  In the case above, we customise the ID for the form using the
+``formid`` option but could change the ``action``, ``method``,
+and more.  For more details, see 
+http://deform.readthedocs.org/en/latest/api.html#deform.Form.
 
 The ``PageEditView`` is registered like any other Pyramid view.  Maybe
 like this:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,7 +82,8 @@ You can then write a ``PageEditView`` using
   class PageEditView(FormView):
       schema = PageSchema()
       buttons = ('save',)
-      form_options = {'formid': 'pyramid-deform'}
+      form_options = (('formid', 'pyramid-deform'),
+                      ('method', 'GET'))
 
       def save_success(self, appstruct):
           context = self.request.context
@@ -105,10 +106,10 @@ it's a required field.
 We use the ``appstruct`` method to pre-fill the form with values from
 the page object that we edit (i.e. ``context``).
 
-We also provide a ``form_options`` dict -- this structure can contain
+We also provide a ``form_options`` two-tuple -- this structure can contain
 any options to be passed as keyword arguments to the form class' ``__init__``
 method.  In the case above, we customise the ID for the form using the
-``formid`` option but could change the ``action``, ``method``,
+``formid`` and ``method`` options but could change the ``action``
 and more.  For more details, see 
 http://deform.readthedocs.org/en/latest/api.html#deform.Form.
 

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -59,10 +59,31 @@ class FormView(object):
         self.request = request
 
     def get_bind_data(self):
+        """
+        Return a ``dict``-like structure to bind to :attr:`schema`.
+
+        By default, this method returns a ``dict`` with :attr:`request` -
+        the object passed to :meth:`__init__`. The returned structure
+        will be passed as keyword arguments to :meth:`schema.bind`.
+        """
         return {'request': self.request}
 
     def __call__(self):
-        """ Prepares and render the form according to provided options.
+        """ 
+        Prepares and render the form according to provided options.
+
+        Upon receiving a ``POST`` request, this method will validate
+        the request against the form instance. After validation, 
+        this calls a method based upon the name of the button used for
+        form submission and whether the validation succeeded or failed.
+        If the button was named ``save``, then :meth:`save_success` will be
+        called on successful validation or :meth:`save_failure` will
+        be called upon failure. An exception to this is when no such
+        ``save_failure`` method is present; in this case, the fallback
+        is :meth:`failure``. 
+        
+        Returns a ``dict`` structure suitable for provision tog the given
+        view. By default, this is the page template specified 
         """
         use_ajax = getattr(self, 'use_ajax', False)
         ajax_options = getattr(self, 'ajax_options', '{}')
@@ -97,31 +118,49 @@ class FormView(object):
         return result
 
     def before(self, form):
-        """ Performs some processing on the ``form`` prior to rendering.
+        """
+        Performs some processing on the ``form`` prior to rendering.
         
         By default, this method does nothing. Override this method
         in your dervived class to modify the ``form``. Your function
         will be executed immediately after instansiating the form
         instance in :meth:`__call__` (thus before obtaining widget resources,
-        considering buttons, or rendering)."""
+        considering buttons, or rendering).
+        """
         pass
 
     def appstruct(self):
-        """ Returns an ``appstruct`` for form default values when rendered.
+        """
+        Returns an ``appstruct`` for form default values when rendered.
 
         By default, this method does nothing. Override this method in
         your dervived class and return a suitable entity that can be
         used as an ``appstruct`` and passed to the
         :meth:`deform.Field.render` of an instance of
-        :attr:`form_class`."""
+        :attr:`form_class`.
+        """
         return None
 
     def failure(self, e):
+        """
+        Default action upon form validation failure.
+
+        Returns the result of :meth:`render` of the given ``e`` object
+        (an instance of :class:`deform.exception.ValidationFailure`) as the
+        ``form`` key in a ``dict`` structure. 
+        """
         return {
             'form': e.render(),
             }
 
     def show(self, form):
+        """
+        Render the given form, with or without an ``appstruct`` context.
+
+        The given ``form`` argument will be rendered with an ``appstruct``
+        if :meth:`appstruct` provides one.  Otherwise, it is rendered without.
+        Returns the rendered form as the ``form`` key in a ``dict`` structure.
+        """
         appstruct = self.appstruct()
         if appstruct is None:
             rendered = form.render()

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -55,6 +55,11 @@ class FormView(object):
     #: Provide your schema in your derived class.
     schema = None
 
+    #: Structure of options to pass as keyword arguments when instantiating
+    #: the form instance of :attr:`form_class`. Any options that can be
+    #: passed to this class' ``__init__`` can be provided here.
+    form_options = {}
+
     def __init__(self, request):
         self.request = request
 
@@ -89,7 +94,8 @@ class FormView(object):
         ajax_options = getattr(self, 'ajax_options', '{}')
         self.schema = self.schema.bind(**self.get_bind_data())
         form = self.form_class(self.schema, buttons=self.buttons,
-                               use_ajax=use_ajax, ajax_options=ajax_options)
+                               use_ajax=use_ajax, ajax_options=ajax_options,
+                               **self.form_options)
         self.before(form)
         reqts = form.get_widget_resources()
         result = None

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -55,10 +55,10 @@ class FormView(object):
     #: Provide your schema in your derived class.
     schema = None
 
-    #: Structure of options to pass as keyword arguments when instantiating
+    #: Two-tuple of options to pass as keyword arguments when instantiating
     #: the form instance of :attr:`form_class`. Any options that can be
     #: passed to this class' ``__init__`` can be provided here.
-    form_options = {}
+    form_options = ()
 
     def __init__(self, request):
         self.request = request
@@ -95,7 +95,7 @@ class FormView(object):
         self.schema = self.schema.bind(**self.get_bind_data())
         form = self.form_class(self.schema, buttons=self.buttons,
                                use_ajax=use_ajax, ajax_options=ajax_options,
-                               **self.form_options)
+                               **dict(self.form_options))
         self.before(form)
         reqts = form.get_widget_resources()
         result = None

--- a/pyramid_deform/tests.py
+++ b/pyramid_deform/tests.py
@@ -127,10 +127,10 @@ class TestFormView(unittest.TestCase):
         inst = self._makeOne(request)
         inst.schema = schema
         inst.form_class = DummyForm
-        form_options = {'formid': 'custom-id',
-                        'action': 'custom-action',
-                        'method': 'GET',
-                        'arbitrary-option': ''}
+        form_options = (('formid', 'custom-id'),
+                        ('action', 'custom-action'),
+                        ('method', 'GET'),
+                        ('arbitrary-option', ''))
         inst.form_options = form_options
 
         def check_form(self, form):
@@ -139,7 +139,7 @@ class TestFormView(unittest.TestCase):
         inst()
         form = inst.form
         # All options should end up on the form, overriding any defaults
-        for key, value in form_options.iteritems():
+        for key, value in dict(form_options).iteritems():
             self.assertEqual(getattr(form, key), value)
 
 class TestFormWizardView(unittest.TestCase):


### PR DESCRIPTION
This new dict setting (tests included) passes its contents to the form instance when being created -- allows for all options that deform.form.Form (and Field) support to be specified.

Also, additional documentation on FormView methods provided.
