### PR TITLE
Enable management of deform static path through Pyramid configuration file.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,3 +110,4 @@ Chris McDonough, 2010/11/27
 Daniel Nouri, 2012/03/30
 Josh Jaques, 2012/04/26
 Alexander Fedorov, 2012/04/26
+Lane Stevens, 2012/09/11

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -478,9 +478,11 @@ def chunks(stream, chunk_size=10000):
 def includeme(config):
     """ Provide useful configuration to a Pyramid ``Configurator`` instance.
 
-    Currently, this hook will set up and register translation paths so
-    for Deform and Colander, add a static view for Deform resources, and
-    configures a template search path (if one is specified by
+    Currently, this hook will set up and register translation paths
+    for Deform and Colander, add a static view for Deform resources (uses
+    ``pyramid_deform.static_path`` from the Pyramid configuration if
+    specified else ``static-deform`` by default), and configures a
+    template search path (if one is specified by
     ``pyramid_deform.template_search_path`` in your Pyramid
     configuration).
     """
@@ -489,6 +491,8 @@ def includeme(config):
         'pyramid_deform.template_search_path', '').strip()
 
     config.add_translation_dirs('colander:locale', 'deform:locale')
-    config.add_static_view('static-deform', 'deform:static')
+    static_path = settings.get(
+        'pyramid_deform.static_path', 'static-deform').strip()
+    config.add_static_view(static_path, 'deform:static')
 
     configure_zpt_renderer(search_path.split())

--- a/pyramid_deform/tests.py
+++ b/pyramid_deform/tests.py
@@ -718,6 +718,23 @@ class TestIncludeMe(unittest.TestCase):
 
         assert config.add_translation_dirs.call_count == 1
         assert config.add_static_view.call_count == 1
+        config.add_static_view.assert_called_with('static-deform', 'deform:static')
+        configure_zpt_renderer.assert_called_with([])
+
+    @patch('pyramid_deform.configure_zpt_renderer')
+    @patch('deform.form.Form')
+    def test_static_path(self, Form, configure_zpt_renderer):
+        from pyramid_deform import includeme
+
+        config = Mock()
+        config.registry.settings = {
+            'pyramid_deform.static_path': 'http://some.domain.com/override/path ', #also tests strip
+            }
+        includeme(config)
+
+        assert config.add_translation_dirs.call_count == 1
+        assert config.add_static_view.call_count == 1
+        config.add_static_view.assert_called_with('http://some.domain.com/override/path', 'deform:static')
         configure_zpt_renderer.assert_called_with([])
 
     @patch('pyramid_deform.configure_zpt_renderer')


### PR DESCRIPTION
configuration file.  If the Pyramid configuration includes a value
for `pyramid_deform.static_path` that will be used to configure the
static path, else the default value of static-deform will be used.
    modified:   CONTRIBUTORS.txt
    modified:   pyramid_deform/**init**.py
    modified:   pyramid_deform/tests.py
