### PR TITLE
Expand documentation, add prepare_form method, add ignore_buttons argument

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+Next release
+------------
+
+- Add ``ignore_buttons`` option to the FormView ``__call__`` method.
+  With this set to ``True``, calling a FormView will result in no button
+  handler methods (success or failure) being called during proccessing.
+  This option allows such a button handler method to render the FormView 
+  as a response.  Without this option, infinite recursion will result.
+
 0.2 (2013-08-01)
 ----------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,13 +5,14 @@ API Documentation
 .. automodule:: pyramid_deform
    :members: includeme
 
-Form view
----------
+Form views
+----------
 
 .. autoclass:: FormView
    :members: 
 
     .. automethod:: __call__
+
 
 Other
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,25 +17,53 @@ Topics
 Installation
 ------------
 
-Install using setuptools, e.g. (within a virtualenv)::
+Install using ``setuptools`` or ``pip``, e.g. (within a virtualenv)::
 
   $ easy_install pyramid_deform
 
-Configuring translations
-------------------------
+or::
 
-pyramid_deform provides an ``includeme`` hook that will set up translation
-paths so that the translations for deform and colander are registered.  It
-also adds a Pyramid static view for the deform JavaScript and CSS resources.
+  $ pip install pyramid_deform
+
+You can also include ``pyramid_deform`` as a ``setup_requires`` dependency
+in your ``setuptools``-compatible project.
+
+Once installed, continue with `Configuration`_ of this package.
+
+
+Configuration
+-------------
+
+Basic configuration
+^^^^^^^^^^^^^^^^^^^
+
+``pyramid_deform`` provides an ``includeme`` hook that will configure your
+``Pyramid`` environment accordingly.  It will:
+
+* Configure and register translations for Deform and Colander
+* Configure template search paths for Deform
+* Add a static view for the Deform JavaScript and CSS resources
+
 To use this in your project, add ``pyramid_deform`` to the
-``pyramid.includes`` in your PasteDeploy configuration file.  An example::
+``pyramid.includes`` in your PasteDeploy configuration file.  For example::
 
   [myapp:main]
   ...
   pyramid.includes = pyramid_debugtoolbar pyramid_tm pyramid_deform
 
+You may also use the ``include`` method against a Pyramid configurator
+(commonly seen as a `config` object) like so::
+
+    def main(global_config, **settings):
+        """ This function returns a Pyramid WSGI application.
+        """
+        config = Configurator(settings=settings)
+        config.include('pyramid_deform')
+        ...
+
+
 Configuring template search paths
----------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``pyramid_deform`` allows you to add one or more template search paths in its
 configuration.  An example::
@@ -51,6 +79,20 @@ Thus, if you put a ``form.pt`` into your application's
 ``form.pt``. Similarly, if you put another ``form.pt`` into the 
 given directory within the ``my.extra`` package, then it will override
 the one in your application and the default from deform.
+
+Configuring the static resource view
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once ``pyramid_deform`` has been included in some fashion in your application,
+it will register a add a static view for Deform resources. By default, this
+static view is configured via
+:meth:`pyramid.config.Configurator.add_static_view` with a ``name`` of
+``static-deform``.  You can customise this by setting the option
+``pyramid_deform.static_path`` within your Pyramid configuration.
+
+This option is to be a string representing an application-relative local URL
+prefix for these static resources. It may alternately be a full URL. 
+
 
 FormView Usage
 --------------

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -73,9 +73,26 @@ class FormView(object):
         """
         return {'request': self.request}
 
+    def prepare_form(self):
+        """
+        Prepares the form object according to the provided options.
+
+        This method, in addition to instantiating an instance of the
+        given :attr:``form_class``, will process the form by calling
+        :meth:`before`. Returns an instance of the :attr:`form_class`.
+        """
+        use_ajax = getattr(self, 'use_ajax', False)
+        ajax_options = getattr(self, 'ajax_options', '{}')
+        self.schema = self.schema.bind(**self.get_bind_data())
+        form = self.form_class(self.schema, buttons=self.buttons,
+                               use_ajax=use_ajax, ajax_options=ajax_options,
+                               **dict(self.form_options))
+        self.before(form)
+        return form
+
     def __call__(self):
         """ 
-        Prepares and render the form according to provided options.
+        Prepares and renders the form according to provided options.
 
         Upon receiving a ``POST`` request, this method will validate
         the request against the form instance. After validation, 
@@ -90,13 +107,7 @@ class FormView(object):
         Returns a ``dict`` structure suitable for provision tog the given
         view. By default, this is the page template specified 
         """
-        use_ajax = getattr(self, 'use_ajax', False)
-        ajax_options = getattr(self, 'ajax_options', '{}')
-        self.schema = self.schema.bind(**self.get_bind_data())
-        form = self.form_class(self.schema, buttons=self.buttons,
-                               use_ajax=use_ajax, ajax_options=ajax_options,
-                               **dict(self.form_options))
-        self.before(form)
+        form = self.prepare_form()
         reqts = form.get_widget_resources()
         result = None
 
@@ -130,8 +141,8 @@ class FormView(object):
         By default, this method does nothing. Override this method
         in your derived class to modify the ``form``. Your function
         will be executed immediately after instansiating the form
-        instance in :meth:`__call__` (thus before obtaining widget resources,
-        considering buttons, or rendering).
+        instance in :meth:`prepare_form` (thus before obtaining widget
+        resources, considering buttons, or rendering during :meth:`__call__`).
         """
         pass
 

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -409,10 +409,10 @@ class CSRFSchema(colander.Schema):
       class MySchema(CSRFSchema):
           my_value = colander.SchemaNode(colander.String())
 
-      And in your application code, *bind* the schema, passing the request
-      as a keyword argument:
+    And in your application code, *bind* the schema, passing the request
+    as a keyword argument:
 
-      .. code-block:: python
+    .. code-block:: python
 
         def aview(request):
             schema = MySchema().bind(request=request)
@@ -526,8 +526,8 @@ def includeme(config):
     Currently, this hook will set up and register translation paths
     for Deform and Colander, add a static view for Deform resources (uses
     ``pyramid_deform.static_path`` from the Pyramid configuration if
-    specified else ``static-deform`` by default), and configures a
-    template search path (if one is specified by
+    specified, otherwise ``static-deform`` by default), and
+    configures one or more template search paths (if specified by
     ``pyramid_deform.template_search_path`` in your Pyramid
     configuration).
     """

--- a/pyramid_deform/tests.py
+++ b/pyramid_deform/tests.py
@@ -59,6 +59,21 @@ class TestFormView(unittest.TestCase):
         result = inst()
         self.assertEqual(result, response)
 
+    def test__call__ignore_buttons(self):
+        schema = DummySchema()
+        request = DummyRequest()
+        request.POST['submit'] = True
+        inst = self._makeOne(request)
+        inst.schema = schema
+        inst.buttons = (DummyButton('submit'), )
+        inst.submit_success = lambda *x: 'success'
+        inst.form_class = DummyForm
+        result = inst(ignore_buttons=True)
+        #Result should not be success - button handler is ignored
+        self.assertEqual(
+            result,
+            {'css_links': (), 'js_links': (), 'form': 'rendered with None'})
+
     def test___call__button_in_request(self):
         schema = DummySchema()
         request = DummyRequest()

--- a/pyramid_deform/tests.py
+++ b/pyramid_deform/tests.py
@@ -142,6 +142,23 @@ class TestFormView(unittest.TestCase):
         for key, value in dict(form_options).items():
             self.assertEqual(getattr(form, key), value)
 
+    def test_prepare_form(self):
+        schema = DummySchema()
+        request = DummyRequest()
+        inst = self._makeOne(request)
+        inst.schema = schema
+        inst.form_class = DummyForm
+
+        def manipulate_form(self, form):
+            form.custom_attr = 'custom-attr'
+
+        inst.before = types.MethodType(manipulate_form, inst)
+        form = inst.prepare_form()
+
+        #Form should be correct type and customised according to options
+        self.assertTrue(isinstance(form, DummyForm))
+        self.assertEqual(form.custom_attr, 'custom-attr')
+
 class TestFormWizardView(unittest.TestCase):
     def _makeOne(self, wizard):
         from pyramid_deform import FormWizardView


### PR DESCRIPTION
This pull request allows the possibility of instantiating the FormView as a means to obtaining an instance of the form it will create.  This is useful in the situation where you have a dedicated FormView for a form and want to re-use the given form (and just the form) on another view.  My specific use-case is rendering the form to display in multiple locations, but only process input on one view.

Rendering the entire FormView can be costly and likely will prove problematic as the **call** method checks things like the request's POST, etc.  This hook allows you to instead get just the form instance out via something like:

```
view = FormView(context, request) #class used as a dedicated view elsewhere
form = view.prepare_form()
...
```

So, this means that you are able to render or do something else with the form, and don't need to re-define the form configuration.

The `ignore_buttons` argument for the FormView.**call** method allows button handler methods to be able to re-render the view (eg by calling `self(ignore_buttons=True)` within a `save_success` method) and change the response before it gets returned to the user.  Previously, trying to do this resulted in infinite recursion since the button handler would effectively call itself.

This also expands on documentation within pyramid_deform concerning the CSRF schema and other aspects.
