### PR TITLE
Fix typo of CRSFSchema to CSRFSchema

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -111,3 +111,4 @@ Daniel Nouri, 2012/03/30
 Josh Jaques, 2012/04/26
 Alexander Fedorov, 2012/04/26
 Lane Stevens, 2012/09/11
+Ye Myat Kaung (Maverick JS), 2013/03/21

--- a/pyramid_deform/__init__.py
+++ b/pyramid_deform/__init__.py
@@ -406,7 +406,7 @@ class CSRFSchema(colander.Schema):
       from pyramid_deform import CSRFSchema
       import colander
 
-      class MySchema(CRSFSchema):
+      class MySchema(CSRFSchema):
           my_value = colander.SchemaNode(colander.String())
 
       And in your application code, *bind* the schema, passing the request


### PR DESCRIPTION
In the **API** documentation under the **Others** section, MySchema subclass'd CRSFSchema instead of CSRFSchema; fixed that typo and updated CONTRIBUTORS.txt
